### PR TITLE
replace ':' in folder path with '+'

### DIFF
--- a/wget_plone.sh
+++ b/wget_plone.sh
@@ -114,6 +114,9 @@ folder=$1
 folder=${folder##http://}
 folder=${folder##https://}
 folder=${folder%%/}
+#present wget version replaces ':' with '+', probably to avoid issues with
+#MacOS style paths.
+folder=${folder//:/+}
 
 #Start formatting our actual web address accordingly
 escaped_address=${1%%/}


### PR DESCRIPTION
This is to match what wget does. The cleanup was failing because the folder could not be found for a site pulled from a local port (eg. wget_plone.sh http://localhost:XXXX/sitename). This got stored in a folder localhost+XXXX, rather than localhost:XXXX, which the script was looking for. This fixes that.